### PR TITLE
fix: handle 204 No Content responses in fetch method

### DIFF
--- a/src/obsidian/index.ts
+++ b/src/obsidian/index.ts
@@ -70,7 +70,11 @@ export class Obsidian {
       );
     }
 
-    return (await response.json()) as T;
+    // Handle 204 No Content responses (empty body crashes JSON.parse)
+    if (status === 204) return null as T;
+    const text = await response.text();
+    if (!text) return null as T;
+    return JSON.parse(text) as T;
   }
 
   status() {


### PR DESCRIPTION
## Summary

The Obsidian REST API returns HTTP 204 with an empty body for write/execute endpoints (POST, PUT, PATCH, DELETE on commands, active file, periodic notes, and vault files).

Calling `response.json()` on an empty body throws a `SyntaxError` ("Unexpected end of JSON input"), which crashes MCP tool calls that perform any write operation.

## Fix

- Check for 204 status code → return `null`
- Read response as text first; if empty → return `null`
- Only parse JSON when there's actual content

## Affected operations

All MCP tools that trigger write endpoints:
- `obsidian_execute_command`
- `obsidian_post_active`, `obsidian_put_active`, `obsidian_patch_active`, `obsidian_delete_active`
- `obsidian_post_file`, `obsidian_put_file`, `obsidian_patch_file`, `obsidian_delete_file`
- `obsidian_post_periodic`, `obsidian_put_periodic`, `obsidian_patch_periodic`, `obsidian_delete_periodic`
- `obsidian_open_file`

## Test plan

- [x] Verified `executeCommand` returns 204 from Obsidian REST API
- [x] Confirmed `response.json()` throws on empty 204 body
- [x] Patch returns `null` cleanly for 204 responses
- [x] Non-204 responses with JSON bodies still parse correctly